### PR TITLE
Feat/verida demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2554,6 +2554,15 @@
             "ms": "2.0.0"
           }
         },
+        "did-document": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/did-document/-/did-document-0.6.2.tgz",
+          "integrity": "sha512-YxiEAqiGR24ULmAu6M+UwMLyCaHSwnXFC9hmP+AI4zNyX1bnH/ffURjPDhKafBMPrVVsBwZSB2iBx6emisDdfg==",
+          "requires": {
+            "did-document-public-key": "^0.5.1",
+            "did-uri": "^0.2.8"
+          }
+        },
         "follow-redirects": {
           "version": "1.5.10",
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,6 +353,43 @@
         "multiformats": "^3.0.3",
         "p-queue": "^6.6.1",
         "typestub-multihashes": "^0.0.4"
+      },
+      "dependencies": {
+        "ipfs-http-client": {
+          "version": "github:simonovic86/ipfs-http-client#4950f4a47c063171edefc0cd7150404ffb1fc087",
+          "from": "github:simonovic86/ipfs-http-client",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "bignumber.js": "^9.0.0",
+            "cids": "^1.0.0",
+            "debug": "^4.1.0",
+            "form-data": "^3.0.0",
+            "ipfs-core-utils": "^0.4.0",
+            "ipfs-utils": "^3.0.0",
+            "ipld-block": "^0.10.0",
+            "ipld-dag-cbor": "^0.17.0",
+            "ipld-dag-pb": "^0.20.0",
+            "ipld-raw": "^6.0.0",
+            "iso-url": "^0.4.7",
+            "it-last": "^1.0.2",
+            "it-map": "^1.0.2",
+            "it-tar": "^1.2.2",
+            "it-to-buffer": "^1.0.0",
+            "it-to-stream": "^0.1.1",
+            "merge-options": "^2.0.0",
+            "multiaddr": "^8.0.0",
+            "multiaddr-to-uri": "^6.0.0",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashes": "^3.0.1",
+            "nanoid": "^3.0.2",
+            "node-fetch": "^2.6.0",
+            "parse-duration": "^0.4.4",
+            "stream-to-it": "^0.2.1",
+            "uint8arrays": "^1.1.0"
+          }
+        }
       }
     },
     "@ceramicnetwork/ceramic-doctype-account-link": {
@@ -817,6 +854,18 @@
         "elliptic": "6.5.3"
       }
     },
+    "@ethersproject/solidity": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.7.tgz",
+      "integrity": "sha512-dUevKUZ06p/VMLP/+cz4QUV+lA17NixucDJfm0ioWF0B3R0Lf+6wqwPchcqiAXlxkNFGIax7WNLgGMh4CkQ8iw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
     "@ethersproject/strings": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.5.tgz",
@@ -841,6 +890,16 @@
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/rlp": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.8.tgz",
+      "integrity": "sha512-3O4MaNHFs05vC5v2ZGqVFVWtO1WyqFejO78M7Qh16njo282aoMlENtVI6cn2B36zOLFXRvYt2pYx6xCG53qKzg==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/wallet": {
@@ -1362,6 +1421,11 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
       }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "@multiformats/base-x": {
       "version": "4.0.1",
@@ -1951,6 +2015,981 @@
         "eslint-visitor-keys": "^2.0.0"
       }
     },
+    "@vechain/ethers": {
+      "version": "4.0.27-3",
+      "resolved": "https://registry.npmjs.org/@vechain/ethers/-/ethers-4.0.27-3.tgz",
+      "integrity": "sha512-R32g5Z9pWTnuxI6MeXoJDYvbHTZAZ0XpIyKVaBxJHKiFhG2QlCI3XPc/ZwwkiSYtweXssh21ihuMk+Q5RHN+6w==",
+      "requires": {
+        "@types/node": "^10.3.2",
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.5.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
+          "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        }
+      }
+    },
+    "@verida/datastore": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@verida/datastore/-/datastore-0.6.3.tgz",
+      "integrity": "sha512-cpCY5rzKkO6AWIfJC078xzBQF+aSZDOs160FQWuGu1VvFlIQ4fgjgcIQO9VIojB3f80isco+4hVJart0+i7I+Q==",
+      "requires": {
+        "@verida/did-helper": "^0.6.0",
+        "@verida/encryption-utils": "^0.2.1",
+        "@verida/wallet-utils": "^1.2.0",
+        "ajv": "^6.12.6",
+        "axios": "^0.19.2",
+        "crypto-pouch": "git+https://github.com/tahpot/crypto-pouch.git",
+        "did-document": "github:arablocks/did-document",
+        "did-jwt": "^4.4.0",
+        "did-jwt-vc": "^0.1.6",
+        "did-resolver": "^1.1.0",
+        "ethers": "^5.0.9",
+        "fs": "0.0.1-security",
+        "json-schema-ref-parser": "^7.1.2",
+        "json-schema-resolve-allof": "^1.5.0",
+        "lodash": "^4.17.15",
+        "ono": "^7.1.2",
+        "pouchdb": "^7.2.1",
+        "pouchdb-find": "^7.1.1",
+        "store": "^2.0.12",
+        "thor-devkit": "^1.2.5",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.0",
+        "url-exists": "^1.0.3",
+        "uuid": "^3.4.0",
+        "web3": "^1.2.9"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.9.tgz",
+          "integrity": "sha512-ily2OufA2DTrxkiHQw5GqbkMSnNKuwZBqKsajtT0ERhZy1r9w2CpW1bmtRMIGzaqQxCdn/GEoFogexk72cBBZQ==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.7.tgz",
+          "integrity": "sha512-NF16JGn6M0zZP5ZS8KtDL2Rh7yHxZbUjBIHLNHMm/0X0BephhjUWy8jqs/Zks6kDJRzNthgmPVy41Ec0RYWPYA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/web": "^5.0.6"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz",
+          "integrity": "sha512-CM5UNmXQaA03MyYARFDDRjHWBxujO41tVle7glf5kHcQsDDULgqSVpkliLJMtPzZjOKFeCVZBHybTZDEZg5zzg==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.8.tgz",
+          "integrity": "sha512-V87DHiZMZR6hmFYmoGaHex0D53UEbZpW75uj8AqPbjYUmi65RB4N2LPRcJXuWuN2R0Y2CxkvW6ArijWychr5FA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.10",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.6.tgz",
+          "integrity": "sha512-HwrGn8YMiUf7bcdVvB4NJ+eWT0BtEFpDtrYxVXEbR7p/XBSJjwiR7DEggIiRvxbualMKg+EZijQWJ3az2li0uw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.6.tgz",
+          "integrity": "sha512-Y/8dowRxBF3bsKkqEp7XN4kcFFQ0o5xxP1YyopfqkXejaOEGiD7ToQdQ0pIZpAJ5GreW56oFOTDDSO6ZcUCNYg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.12.tgz",
+          "integrity": "sha512-mbFZjwthx6vFlHG9owXP/C5QkNvsA+xHpDCkPPPdG2n1dS9AmZAL5DI0InNLid60rQWL3MXpEl19tFmtL7Q9jw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.8",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.8.tgz",
+          "integrity": "sha512-O+sJNVGzzuy51g+EMK8BegomqNIg+C2RO6vOt0XP6ac4o4saiq69FnjlsrNslaiMFVO7qcEHBsWJ9hx1tj1lMw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.7.tgz",
+          "integrity": "sha512-cbQK1UpE4hamB52Eg6DLhJoXeQ1plSzekh5Ujir1xdREdwdsZPPXKczkrWqBBR0KyywJZHN/o/hj0w8j7scSGg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.8.tgz",
+          "integrity": "sha512-PecBL4vnsrpuks2lzzkRsOts8csJy338HNDKDIivbFmx92BVzh3ohOOv3XsoYPSXIHQvobF959W+aSk3RCZL/g==",
+          "requires": {
+            "@ethersproject/abi": "^5.0.5",
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.8.tgz",
+          "integrity": "sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.7.tgz",
+          "integrity": "sha512-89tphqlji4y/LNE1cSaMQ3hrBtJ4lO1qWGi2hn54LiHym85DTw+zAKbA8QgmdSdJDLGR/kc9VHaIPQ+vZQ2LkQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/wordlists": "^5.0.4"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.9.tgz",
+          "integrity": "sha512-EWuFvJd8nu90dkmJwmJddxOYCvFvMkKBsZi8rxTme2XEZsHKOFnybVkoL23u7ZtApuEfTKmVcR2PTwgZwqDsKw==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hdnode": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.6.tgz",
+          "integrity": "sha512-eJ4Id/i2rwrf5JXEA7a12bG1phuxjj47mPZgDUbttuNBodhSuZF2nEO5QdpaRjmlphQ8Kt9PNqY/z7lhtJptZg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.6.tgz",
+          "integrity": "sha512-2Cg1N5109zzFOBfkyuPj+FfF7ioqAsRffmybJ2lrsiB5skphIAE72XNSCs4fqktlf+rwSh/5o/UXRjXxvSktZw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.6.tgz",
+          "integrity": "sha512-CUYciSxR/AaCoKMJk3WUW+BDhR41G3C+O9lOeZ4bR1wDhLKL2Z8p0ciF5XDEiVbmI4CToW6boVKybeVMdngRrg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/sha2": "^5.0.3"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.6.tgz",
+          "integrity": "sha512-a9DUMizYhJ0TbtuDkO9iYlb2CDlpSKqGPDr+amvlZhRspQ6jbl5Eq8jfu4SCcGlcfaTbguJmqGnyOGn1EFt6xA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.0.17",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.17.tgz",
+          "integrity": "sha512-bJnvs5X7ttU5x2ekGJYG7R3Z+spZawLFfR0IDsbaMDLiCwZOyrgk+VTBU7amSFLT0WUhWFv8WwSUB+AryCQG1Q==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/web": "^5.0.6",
+            "bech32": "1.1.4",
+            "ws": "7.2.3"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.6.tgz",
+          "integrity": "sha512-8nsVNaZvZ9OD5NXfzE4mmz8IH/1DYJbAR95xpRxZkIuNmfn6QlMp49ccJYZWGhs6m0Zj2+FXjx3pzXfYlo9/dA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.6.tgz",
+          "integrity": "sha512-M223MTaydfmQSsvqAl0FJZDYFlSqt6cgbhnssLDwqCKYegAHE16vrFyo+eiOapYlt32XAIJm0BXlqSunULzZuQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.6.tgz",
+          "integrity": "sha512-30gypDLkfkP5gE3llqi0jEuRV8m4/nvzeqmqMxiihZ7veFQHqDaGpyFeHzFim+qGeH9fq0lgYjavLvwW69+Fkw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "hash.js": "1.1.3"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.7.tgz",
+          "integrity": "sha512-JYndnhFPKH0daPcIjyhi+GMcw3srIHkQ40hGRe6DA0CdGrpMfgyfSYDQ2D8HL2lgR+Xm4SHfEB0qba6+sCyrvg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "elliptic": "6.5.3"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.7.tgz",
+          "integrity": "sha512-a+6T80LvmXGMOOWQTZHtGGQEg1z4v8rm8oX70KNs55YtPXI/5J3LBbVf5pyqCKSlmiBw5IaepPvs5XGalRUSZQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.8.tgz",
+          "integrity": "sha512-i7NtOXVzUe+YSU6QufzlRrI2WzHaTmULAKHJv4duIZMLqzehCBXGA9lTpFgFdqGYcQJ7vOtNFC2BB2mSjmuXqg==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        },
+        "@ethersproject/wallet": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.9.tgz",
+          "integrity": "sha512-GfpQF56PO/945SJq7Wdg5F5U6wkxaDgkAzcgGbCW6Joz8oW8MzKItkvYCzMh+j/8gJMzFncsuqX4zg2gq3J6nQ==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/hdnode": "^5.0.4",
+            "@ethersproject/json-wallets": "^5.0.6",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/wordlists": "^5.0.4"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.11.tgz",
+          "integrity": "sha512-x03ihbPoN1S8Gsh9WSwxkYxUIumLi02ZEKJku1C43sxBfe+mdprWyvujzYlpuoRNfWRgNhdRDKMP8JbG6MwNGA==",
+          "requires": {
+            "@ethersproject/base64": "^5.0.3",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.7.tgz",
+          "integrity": "sha512-ZjQtYxm41FmHfYgpkdQG++EDcBPQWv9O6FfP6NndYRVaXaQZh6eq3sy7HQP8zCZ8dznKgy6ZyKECS8qdvnGHwA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "did-resolver": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-1.1.0.tgz",
+          "integrity": "sha512-Q02Sc5VuQnJzzR8fQ/DzyCHiYb31WpQdocOsxppI66wwT4XalYRDeCr3a48mL6sYPQo76AkBh0mxte9ZBuQzxA=="
+        },
+        "ethers": {
+          "version": "5.0.23",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.23.tgz",
+          "integrity": "sha512-f3pTcgYpMhtmMTMG9KO6pWHYjrCiGz7yVnvMsTQgAYfAVAeUxKy2H1cxQJyqyghRjtAvgVYJlnXQo8mMCD63BA==",
+          "requires": {
+            "@ethersproject/abi": "5.0.9",
+            "@ethersproject/abstract-provider": "5.0.7",
+            "@ethersproject/abstract-signer": "5.0.9",
+            "@ethersproject/address": "5.0.8",
+            "@ethersproject/base64": "5.0.6",
+            "@ethersproject/basex": "5.0.6",
+            "@ethersproject/bignumber": "5.0.12",
+            "@ethersproject/bytes": "5.0.8",
+            "@ethersproject/constants": "5.0.7",
+            "@ethersproject/contracts": "5.0.8",
+            "@ethersproject/hash": "5.0.8",
+            "@ethersproject/hdnode": "5.0.7",
+            "@ethersproject/json-wallets": "5.0.9",
+            "@ethersproject/keccak256": "5.0.6",
+            "@ethersproject/logger": "5.0.8",
+            "@ethersproject/networks": "5.0.6",
+            "@ethersproject/pbkdf2": "5.0.6",
+            "@ethersproject/properties": "5.0.6",
+            "@ethersproject/providers": "5.0.17",
+            "@ethersproject/random": "5.0.6",
+            "@ethersproject/rlp": "5.0.6",
+            "@ethersproject/sha2": "5.0.6",
+            "@ethersproject/signing-key": "5.0.7",
+            "@ethersproject/solidity": "5.0.7",
+            "@ethersproject/strings": "5.0.7",
+            "@ethersproject/transactions": "5.0.8",
+            "@ethersproject/units": "5.0.8",
+            "@ethersproject/wallet": "5.0.9",
+            "@ethersproject/web": "5.0.11",
+            "@ethersproject/wordlists": "5.0.7"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "@verida/did-helper": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@verida/did-helper/-/did-helper-0.6.1.tgz",
+      "integrity": "sha512-hVbis5Pn/xvZzzYHDqtMPs4NliJmQ+Qy8o35A6LnmTJlExDdSXgSNrhHikQsbG5sHT0lhDo3hN1a2aXBXPIwsg==",
+      "requires": {
+        "@verida/wallet-utils": "^1.2.0",
+        "axios": "^0.19.1",
+        "did-document": "^0.6.2",
+        "did-jwt": "^4.0.0",
+        "tweetnacl": "^1.0.2",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "@verida/encryption-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@verida/encryption-utils/-/encryption-utils-0.2.1.tgz",
+      "integrity": "sha512-e/HUFTcG90oO8zGFroq7nPdxO3pP6zQATmktZXcVa6krQE6ug9TSjbfriACw17aCT5ps4jRdwgTdFsl93rHzYQ==",
+      "requires": {
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+        }
+      }
+    },
+    "@verida/wallet-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@verida/wallet-utils/-/wallet-utils-1.2.0.tgz",
+      "integrity": "sha512-OyqiDk3k836DU3K7PH4HUo8F629NgSVYA6OOQ3R8lbyZyS6Q21a8CQWfX8W7lIMGaHG3VD4HenDvdOahSTKRGQ==",
+      "requires": {
+        "ethers": "^5.0.5",
+        "thor-devkit": "^1.2.5"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.9.tgz",
+          "integrity": "sha512-ily2OufA2DTrxkiHQw5GqbkMSnNKuwZBqKsajtT0ERhZy1r9w2CpW1bmtRMIGzaqQxCdn/GEoFogexk72cBBZQ==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.7.tgz",
+          "integrity": "sha512-NF16JGn6M0zZP5ZS8KtDL2Rh7yHxZbUjBIHLNHMm/0X0BephhjUWy8jqs/Zks6kDJRzNthgmPVy41Ec0RYWPYA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/web": "^5.0.6"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.9.tgz",
+          "integrity": "sha512-CM5UNmXQaA03MyYARFDDRjHWBxujO41tVle7glf5kHcQsDDULgqSVpkliLJMtPzZjOKFeCVZBHybTZDEZg5zzg==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.8.tgz",
+          "integrity": "sha512-V87DHiZMZR6hmFYmoGaHex0D53UEbZpW75uj8AqPbjYUmi65RB4N2LPRcJXuWuN2R0Y2CxkvW6ArijWychr5FA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.10",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.6.tgz",
+          "integrity": "sha512-HwrGn8YMiUf7bcdVvB4NJ+eWT0BtEFpDtrYxVXEbR7p/XBSJjwiR7DEggIiRvxbualMKg+EZijQWJ3az2li0uw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.6.tgz",
+          "integrity": "sha512-Y/8dowRxBF3bsKkqEp7XN4kcFFQ0o5xxP1YyopfqkXejaOEGiD7ToQdQ0pIZpAJ5GreW56oFOTDDSO6ZcUCNYg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.12.tgz",
+          "integrity": "sha512-mbFZjwthx6vFlHG9owXP/C5QkNvsA+xHpDCkPPPdG2n1dS9AmZAL5DI0InNLid60rQWL3MXpEl19tFmtL7Q9jw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.8",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.8.tgz",
+          "integrity": "sha512-O+sJNVGzzuy51g+EMK8BegomqNIg+C2RO6vOt0XP6ac4o4saiq69FnjlsrNslaiMFVO7qcEHBsWJ9hx1tj1lMw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.7.tgz",
+          "integrity": "sha512-cbQK1UpE4hamB52Eg6DLhJoXeQ1plSzekh5Ujir1xdREdwdsZPPXKczkrWqBBR0KyywJZHN/o/hj0w8j7scSGg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.8.tgz",
+          "integrity": "sha512-PecBL4vnsrpuks2lzzkRsOts8csJy338HNDKDIivbFmx92BVzh3ohOOv3XsoYPSXIHQvobF959W+aSk3RCZL/g==",
+          "requires": {
+            "@ethersproject/abi": "^5.0.5",
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.8.tgz",
+          "integrity": "sha512-Qay01tcFyFreYjSMt82rOQGMfQDmLm1sj3iNNO1BhrVf840xgBZuJ7gBATERzAjTuTCHUHw9BuGwxErJUS95yg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.6",
+            "@ethersproject/address": "^5.0.5",
+            "@ethersproject/bignumber": "^5.0.8",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.7.tgz",
+          "integrity": "sha512-89tphqlji4y/LNE1cSaMQ3hrBtJ4lO1qWGi2hn54LiHym85DTw+zAKbA8QgmdSdJDLGR/kc9VHaIPQ+vZQ2LkQ==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/wordlists": "^5.0.4"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.9.tgz",
+          "integrity": "sha512-EWuFvJd8nu90dkmJwmJddxOYCvFvMkKBsZi8rxTme2XEZsHKOFnybVkoL23u7ZtApuEfTKmVcR2PTwgZwqDsKw==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hdnode": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/pbkdf2": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.6.tgz",
+          "integrity": "sha512-eJ4Id/i2rwrf5JXEA7a12bG1phuxjj47mPZgDUbttuNBodhSuZF2nEO5QdpaRjmlphQ8Kt9PNqY/z7lhtJptZg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+          "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.6.tgz",
+          "integrity": "sha512-2Cg1N5109zzFOBfkyuPj+FfF7ioqAsRffmybJ2lrsiB5skphIAE72XNSCs4fqktlf+rwSh/5o/UXRjXxvSktZw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.6.tgz",
+          "integrity": "sha512-CUYciSxR/AaCoKMJk3WUW+BDhR41G3C+O9lOeZ4bR1wDhLKL2Z8p0ciF5XDEiVbmI4CToW6boVKybeVMdngRrg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/sha2": "^5.0.3"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.6.tgz",
+          "integrity": "sha512-a9DUMizYhJ0TbtuDkO9iYlb2CDlpSKqGPDr+amvlZhRspQ6jbl5Eq8jfu4SCcGlcfaTbguJmqGnyOGn1EFt6xA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.0.17",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.17.tgz",
+          "integrity": "sha512-bJnvs5X7ttU5x2ekGJYG7R3Z+spZawLFfR0IDsbaMDLiCwZOyrgk+VTBU7amSFLT0WUhWFv8WwSUB+AryCQG1Q==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/basex": "^5.0.3",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/networks": "^5.0.3",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/sha2": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/web": "^5.0.6",
+            "bech32": "1.1.4",
+            "ws": "7.2.3"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.6.tgz",
+          "integrity": "sha512-8nsVNaZvZ9OD5NXfzE4mmz8IH/1DYJbAR95xpRxZkIuNmfn6QlMp49ccJYZWGhs6m0Zj2+FXjx3pzXfYlo9/dA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.6.tgz",
+          "integrity": "sha512-M223MTaydfmQSsvqAl0FJZDYFlSqt6cgbhnssLDwqCKYegAHE16vrFyo+eiOapYlt32XAIJm0BXlqSunULzZuQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.6.tgz",
+          "integrity": "sha512-30gypDLkfkP5gE3llqi0jEuRV8m4/nvzeqmqMxiihZ7veFQHqDaGpyFeHzFim+qGeH9fq0lgYjavLvwW69+Fkw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "hash.js": "1.1.3"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.7.tgz",
+          "integrity": "sha512-JYndnhFPKH0daPcIjyhi+GMcw3srIHkQ40hGRe6DA0CdGrpMfgyfSYDQ2D8HL2lgR+Xm4SHfEB0qba6+sCyrvg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "elliptic": "6.5.3"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.7.tgz",
+          "integrity": "sha512-a+6T80LvmXGMOOWQTZHtGGQEg1z4v8rm8oX70KNs55YtPXI/5J3LBbVf5pyqCKSlmiBw5IaepPvs5XGalRUSZQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.8.tgz",
+          "integrity": "sha512-i7NtOXVzUe+YSU6QufzlRrI2WzHaTmULAKHJv4duIZMLqzehCBXGA9lTpFgFdqGYcQJ7vOtNFC2BB2mSjmuXqg==",
+          "requires": {
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/constants": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/rlp": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4"
+          }
+        },
+        "@ethersproject/wallet": {
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.9.tgz",
+          "integrity": "sha512-GfpQF56PO/945SJq7Wdg5F5U6wkxaDgkAzcgGbCW6Joz8oW8MzKItkvYCzMh+j/8gJMzFncsuqX4zg2gq3J6nQ==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.0.4",
+            "@ethersproject/abstract-signer": "^5.0.4",
+            "@ethersproject/address": "^5.0.4",
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/hdnode": "^5.0.4",
+            "@ethersproject/json-wallets": "^5.0.6",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/random": "^5.0.3",
+            "@ethersproject/signing-key": "^5.0.4",
+            "@ethersproject/transactions": "^5.0.5",
+            "@ethersproject/wordlists": "^5.0.4"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.0.11",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.11.tgz",
+          "integrity": "sha512-x03ihbPoN1S8Gsh9WSwxkYxUIumLi02ZEKJku1C43sxBfe+mdprWyvujzYlpuoRNfWRgNhdRDKMP8JbG6MwNGA==",
+          "requires": {
+            "@ethersproject/base64": "^5.0.3",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.7.tgz",
+          "integrity": "sha512-ZjQtYxm41FmHfYgpkdQG++EDcBPQWv9O6FfP6NndYRVaXaQZh6eq3sy7HQP8zCZ8dznKgy6ZyKECS8qdvnGHwA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/hash": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/properties": "^5.0.3",
+            "@ethersproject/strings": "^5.0.4"
+          }
+        },
+        "ethers": {
+          "version": "5.0.23",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.23.tgz",
+          "integrity": "sha512-f3pTcgYpMhtmMTMG9KO6pWHYjrCiGz7yVnvMsTQgAYfAVAeUxKy2H1cxQJyqyghRjtAvgVYJlnXQo8mMCD63BA==",
+          "requires": {
+            "@ethersproject/abi": "5.0.9",
+            "@ethersproject/abstract-provider": "5.0.7",
+            "@ethersproject/abstract-signer": "5.0.9",
+            "@ethersproject/address": "5.0.8",
+            "@ethersproject/base64": "5.0.6",
+            "@ethersproject/basex": "5.0.6",
+            "@ethersproject/bignumber": "5.0.12",
+            "@ethersproject/bytes": "5.0.8",
+            "@ethersproject/constants": "5.0.7",
+            "@ethersproject/contracts": "5.0.8",
+            "@ethersproject/hash": "5.0.8",
+            "@ethersproject/hdnode": "5.0.7",
+            "@ethersproject/json-wallets": "5.0.9",
+            "@ethersproject/keccak256": "5.0.6",
+            "@ethersproject/logger": "5.0.8",
+            "@ethersproject/networks": "5.0.6",
+            "@ethersproject/pbkdf2": "5.0.6",
+            "@ethersproject/properties": "5.0.6",
+            "@ethersproject/providers": "5.0.17",
+            "@ethersproject/random": "5.0.6",
+            "@ethersproject/rlp": "5.0.6",
+            "@ethersproject/sha2": "5.0.6",
+            "@ethersproject/signing-key": "5.0.7",
+            "@ethersproject/solidity": "5.0.7",
+            "@ethersproject/strings": "5.0.7",
+            "@ethersproject/transactions": "5.0.8",
+            "@ethersproject/units": "5.0.8",
+            "@ethersproject/wallet": "5.0.9",
+            "@ethersproject/web": "5.0.11",
+            "@ethersproject/wordlists": "5.0.7"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
     "@walletconnect/client": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/client/-/client-1.3.1.tgz",
@@ -2385,6 +3424,11 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -2444,7 +3488,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
@@ -2452,8 +3495,7 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         }
       }
     },
@@ -2480,6 +3522,11 @@
         }
       }
     },
+    "argsarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
+      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2504,6 +3551,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
       "version": "3.1.1",
@@ -2613,6 +3665,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -2973,6 +4030,11 @@
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
       "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
     },
+    "base62": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
+      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
+    },
     "base64-arraybuffer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
@@ -3146,13 +4208,49 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
       "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
     },
     "borc": {
       "version": "2.1.2",
@@ -3474,6 +4572,11 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -3498,6 +4601,21 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bufferutil": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
+      "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        }
+      }
     },
     "bufio": {
       "version": "1.0.7",
@@ -3619,6 +4737,11 @@
         "get-intrinsic": "^1.0.0"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "callback-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/callback-stream/-/callback-stream-1.1.0.tgz",
@@ -3714,6 +4837,50 @@
       "requires": {
         "bignumber.js": "^9.0.0",
         "nofilter": "^1.0.4"
+      }
+    },
+    "chacha": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chacha/-/chacha-2.1.0.tgz",
+      "integrity": "sha1-9NV8h2ihtCBumWf4WLSNp90o6qY=",
+      "requires": {
+        "chacha-native": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "chacha-native": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chacha-native/-/chacha-native-2.0.3.tgz",
+      "integrity": "sha512-93h+osfjhR2sMHAaapTLlL/COoBPEZ6upicPBQ4GfUyadoMb8t9/M0PKK8kC+F+DEA/Oy3Kg9w3HzY3J1foP3g==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.1",
+        "nan": "^2.4.0"
       }
     },
     "chai": {
@@ -3841,8 +5008,7 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -4077,6 +5243,11 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -4135,6 +5306,36 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "requires": {
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
     },
     "component-bind": {
       "version": "1.0.0",
@@ -4247,6 +5448,104 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "content-hash": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/content-hash/-/content-hash-2.5.2.tgz",
+      "integrity": "sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw==",
+      "requires": {
+        "cids": "^0.7.1",
+        "multicodec": "^0.5.5",
+        "multihashes": "^0.4.15"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "^1.0.0",
+            "multihashes": "~0.4.15"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+          "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+          "requires": {
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "varint": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -4266,6 +5565,11 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -4295,6 +5599,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -4368,6 +5681,18 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-pouch": {
+      "version": "git+https://github.com/tahpot/crypto-pouch.git#910feb51dd006d9a05639d984501eeda77e213bf",
+      "from": "git+https://github.com/tahpot/crypto-pouch.git",
+      "requires": {
+        "chacha": "^2.1.0",
+        "native-crypto": "^1.5.2",
+        "pouchdb-promise": "^6.1.0",
+        "randombytes": "^2.0.3",
+        "transform-pouch": "^1.1.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -4414,6 +5739,15 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
     },
     "dag-cbor-links": {
       "version": "2.0.2",
@@ -4691,6 +6025,11 @@
         }
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
     "delay": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
@@ -4711,6 +6050,11 @@
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
       "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -4719,6 +6063,11 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-browser": {
       "version": "5.1.0",
@@ -4740,6 +6089,31 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
+    },
+    "detective": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+      "requires": {
+        "acorn": "^5.2.1",
+        "defined": "^1.0.0"
+      }
+    },
+    "did-document": {
+      "version": "github:arablocks/did-document#873dcc3729b15c0c205856d0bea2515e3c98272c",
+      "from": "github:arablocks/did-document",
+      "requires": {
+        "did-document-public-key": "^0.5.1",
+        "did-uri": "^0.2.8"
+      }
+    },
+    "did-document-public-key": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/did-document-public-key/-/did-document-public-key-0.5.1.tgz",
+      "integrity": "sha512-lFLbwkDo6g1a+qeyBJ5Jrj3bkwQZaUaSn+71QZ1kkmeJJ04MMCpvweFNqRrcPYZDhploxWcPa4a/OHRDqBXG/w==",
+      "requires": {
+        "ld-cryptosuite-registry": "^0.3.x"
+      }
     },
     "did-jwt": {
       "version": "4.6.2",
@@ -4766,10 +6140,26 @@
         }
       }
     },
+    "did-jwt-vc": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/did-jwt-vc/-/did-jwt-vc-0.1.6.tgz",
+      "integrity": "sha512-sRqUlCYKTygJ45aH0A5GSEH76NhCxIRoDIqty+pCu1KhxUbXxJgpY8+TTfffjdlitXZKt3m9Twh4LSCJpW920Q==",
+      "requires": {
+        "did-jwt": "^4.3.2"
+      }
+    },
     "did-resolver": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-2.1.1.tgz",
       "integrity": "sha512-FYLTkNWofjYNDGV1HTQlyVu1OqZiFxR4I8KM+oxGVOkbXva15NfWzbzciqdXUDqOhe6so5aroAdrVip6gSAYSA=="
+    },
+    "did-uri": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/did-uri/-/did-uri-0.2.8.tgz",
+      "integrity": "sha512-JUOLS8wbyYdpz/yNEPFlxYz0wJ4kSFs6OyeewV79ngGoyAPV17wgteG9RE5rPzishF2Dur/IGMIj9LCH+OWNZw==",
+      "requires": {
+        "qs": "^6.5.1"
+      }
     },
     "dids": {
       "version": "0.7.0",
@@ -4895,6 +6285,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "drbg.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
@@ -4987,6 +6382,19 @@
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
         }
       }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron": {
       "version": "1.8.8",
@@ -5155,6 +6563,11 @@
         }
       }
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
@@ -5204,6 +6617,14 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "end-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/end-stream/-/end-stream-0.1.0.tgz",
+      "integrity": "sha1-MgA/P0OKKwFDFoE3+PpumGbIHtU=",
+      "requires": {
+        "write-stream": "~0.4.3"
       }
     },
     "engine.io": {
@@ -5361,10 +6782,56 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es3ify": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
+      "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
+      "requires": {
+        "esprima": "^2.7.1",
+        "jstransform": "~11.0.0",
+        "through": "~2.3.4"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        }
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -5375,6 +6842,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
       "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5724,6 +7196,11 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "esmangle-evaluator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
+      "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
+    },
     "espree": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
@@ -5798,6 +7275,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "eth-block-tracker": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-4.4.3.tgz",
@@ -5809,6 +7291,15 @@
         "json-rpc-random-id": "^1.0.1",
         "pify": "^3.0.0",
         "safe-event-emitter": "^1.0.1"
+      }
+    },
+    "eth-ens-namehash": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
+      "requires": {
+        "idna-uts46-hx": "^2.3.1",
+        "js-sha3": "^0.5.7"
       }
     },
     "eth-json-rpc-errors": {
@@ -5928,6 +7419,21 @@
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
+      }
+    },
+    "ethereum-bloom-filters": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+      "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
+      "requires": {
+        "js-sha3": "^0.8.0"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
       }
     },
     "ethereum-checksum-address": {
@@ -6371,6 +7877,93 @@
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
       "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "ext": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "requires": {
+        "type": "^2.0.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6491,6 +8084,29 @@
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "requires": {
         "checkpoint-store": "^1.1.0"
+      }
+    },
+    "falafel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+      "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
+      "requires": {
+        "acorn": "^1.0.3",
+        "foreach": "^2.0.5",
+        "isarray": "0.0.1",
+        "object-keys": "^1.0.6"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+          "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
       }
     },
     "fast-deep-equal": {
@@ -6651,6 +8267,14 @@
         "pend": "~1.2.0"
       }
     },
+    "fetch-cookie": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.10.1.tgz",
+      "integrity": "sha512-beB+VEd4cNeVG1PY+ee74+PkuCQnik78pgLi5Ah/7qdUfov8IctU0vLUbBT8/10Ma5GMBeI4wtxhGrEfKNYs2g==",
+      "requires": {
+        "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
+      }
+    },
     "fetch-ponyfill": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
@@ -6724,6 +8348,35 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -6848,6 +8501,11 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6868,6 +8526,11 @@
       "resolved": "https://registry.npmjs.org/fortmatic/-/fortmatic-2.2.1.tgz",
       "integrity": "sha512-PEfPoErJSErU2A8iYD2Mab2c8eJK5dCdCr1jR/8yc49aEAlyQ4UXnZXyeO6MU5zBGkDAZmg9brnRSPzc+8MKPQ=="
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -6875,6 +8538,11 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "from2": {
       "version": "2.3.0",
@@ -6918,6 +8586,11 @@
         }
       }
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs-extra": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
@@ -6927,6 +8600,14 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^1.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -7775,10 +9456,23 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -7908,6 +9602,30 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "http-https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+      "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7957,6 +9675,21 @@
         "rpc-utils": "^0.1.2",
         "store": "^2.0.12",
         "uint8arrays": "^1.1.0"
+      }
+    },
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        }
       }
     },
     "ieee754": {
@@ -8053,6 +9786,47 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
+    "inline-process-browser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
+      "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
+      "requires": {
+        "falafel": "^1.0.1",
+        "through2": "^0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
+    },
     "interface-datastore": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
@@ -8144,6 +9918,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
       "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs": {
       "version": "0.51.0",
@@ -9728,6 +11507,11 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -9753,6 +11537,11 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -9901,6 +11690,15 @@
       "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "requires": {
         "html-escaper": "^2.0.0"
+      }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "it-all": {
@@ -10600,7 +12398,6 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -10688,6 +12485,39 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-ref-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
+      "integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^6.0.0"
+      },
+      "dependencies": {
+        "ono": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
+          "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
+        }
+      }
+    },
+    "json-schema-resolve-allof": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/json-schema-resolve-allof/-/json-schema-resolve-allof-1.5.0.tgz",
+      "integrity": "sha512-Jgn6BQGSLDp3D7bTYrmCbP/p7SRFz5BfpeEJ9A7sXuVADMc14aaDN1a49zqk9D26wwJlcNvjRpT63cz1VgFZeg==",
+      "requires": {
+        "get-stdin": "^5.0.1",
+        "lodash": "^4.14.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10769,6 +12599,38 @@
         "verror": "1.10.0"
       }
     },
+    "jstransform": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+      "requires": {
+        "base62": "^1.1.0",
+        "commoner": "^0.10.1",
+        "esprima-fb": "^15001.1.0-dev-harmony-fb",
+        "object-assign": "^2.0.0",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
     "jsx-ast-utils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
@@ -10798,6 +12660,28 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/just-safe-set/-/just-safe-set-2.1.0.tgz",
       "integrity": "sha512-wSTg/2bQpzyivBYbWPqQgafdfxW0tr3hX9qYGDRS2ws+AXwc7tvn8ABqkp8iPQHChjj4F5JvL3t0FQLbcNuKig=="
+    },
+    "jwk-to-pem": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-1.2.6.tgz",
+      "integrity": "sha1-1QfOzkAInFJI4J7GgmaiAwqcYyU=",
+      "requires": {
+        "asn1.js": "^4.5.2",
+        "elliptic": "^6.2.3",
+        "safe-buffer": "^5.0.1"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+          "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
     },
     "k-bucket": {
       "version": "5.0.0",
@@ -10870,6 +12754,11 @@
       "requires": {
         "package-json": "^6.3.0"
       }
+    },
+    "ld-cryptosuite-registry": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ld-cryptosuite-registry/-/ld-cryptosuite-registry-0.3.3.tgz",
+      "integrity": "sha512-5Rl9moffoRtF4qdFYYCf5/3gJdnLl7VIAdO82V5uoSDHe7gyn5W1Wv72UssMjeb83iDIakH1in1kuTZpiNE81w=="
     },
     "left-pad": {
       "version": "1.3.0",
@@ -11067,6 +12956,14 @@
         "level": "^5.0.1",
         "levelgraph": "^2.1.1",
         "ts-jest": "^24.0.2"
+      }
+    },
+    "level-write-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/level-write-stream/-/level-write-stream-1.0.0.tgz",
+      "integrity": "sha1-P3+7Z5pVE3wP6zA97nZuEu4Twdw=",
+      "requires": {
+        "end-stream": "~0.1.0"
       }
     },
     "level-ws": {
@@ -11711,6 +13608,21 @@
         "p-timeout": "^3.2.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      },
+      "dependencies": {
+        "immediate": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        }
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -11945,6 +13857,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "memdown": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
@@ -12110,6 +14027,11 @@
           }
         }
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-options": {
       "version": "2.0.0",
@@ -12327,6 +14249,11 @@
         }
       }
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -12355,6 +14282,11 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.44.0",
@@ -12424,6 +14356,30 @@
           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
           "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         }
+      }
+    },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
       }
     },
     "mississippi": {
@@ -12512,6 +14468,19 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mkdirp-promise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+      "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
+      "requires": {
+        "mkdirp": "*"
+      }
+    },
+    "mock-fs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.13.0.tgz",
+      "integrity": "sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA=="
     },
     "mortice": {
       "version": "2.0.0",
@@ -12755,6 +14724,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
+    "nano-json-stream-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
+      "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
     "nanoid": {
       "version": "3.1.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
@@ -12789,6 +14763,58 @@
       "integrity": "sha512-YIxU5nWqSHG1Xbu3eOu3pdFRD882ivQpIcu6AiPVe2oSVoRbfYW63DVkZm3g1gHiMtZSvZzF6THSzTGEBYl8YA==",
       "requires": {
         "globalthis": "^1.0.1"
+      }
+    },
+    "native-crypto": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/native-crypto/-/native-crypto-1.8.1.tgz",
+      "integrity": "sha512-A+nv9MY/ZYxqhB86DQUrLPfbljqMmGhWM0Z3iTgKi9NvBgi4cj4H/7uFA3c2W/rx5M9VOr+zkvQURsAQB/uuPg==",
+      "requires": {
+        "asn1.js": "^4.5.0",
+        "bn.js": "^4.10.3",
+        "browserify-aes": "^1.0.5",
+        "browserify-sign": "^4.0.0",
+        "buffer-equal-constant-time": "^1.0.1",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "debug": "^2.2.0",
+        "ecdsa-sig-formatter": "^1.0.7",
+        "elliptic": "^6.0.1",
+        "jwk-to-pem": "^1.2.2",
+        "miller-rabin": "^4.0.0",
+        "minimalistic-assert": "^1.0.0",
+        "pbkdf2": "^3.0.4",
+        "pemstrip": "0.0.1",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.2",
+        "raw-ecdsa": "^1.1.1",
+        "rsa-keygen": "^1.0.5"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+          "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "native-fetch": {
@@ -12871,6 +14897,11 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -13397,10 +15428,26 @@
         "has": "^1.0.3"
       }
     },
+    "oboe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+      "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+      "requires": {
+        "http-https": "^1.0.0"
+      }
+    },
     "observable-webworkers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
       "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ=="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -13416,6 +15463,14 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-9jnfVriq7uJM4o5ganUY54ntUm+5EK21EGaQ5NWnkWg3zz5ywbbonlBguRcnmF1/HDiIe3zxNxXcO1YPBmPcQQ==",
+      "requires": {
+        "@jsdevtools/ono": "7.1.3"
       }
     },
     "opencollective-postinstall": {
@@ -13733,6 +15788,11 @@
         "better-assert": "~1.0.0"
       }
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -13837,6 +15897,11 @@
       "requires": {
         "asn1.js": "^5.0.1"
       }
+    },
+    "pemstrip": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz",
+      "integrity": "sha1-OfcHFyDPoT1ULJvedfH6W/nQiAY="
     },
     "pend": {
       "version": "1.2.0",
@@ -14007,6 +16072,282 @@
         "shortid": "^2.2.8"
       }
     },
+    "pouchdb": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb/-/pouchdb-7.2.2.tgz",
+      "integrity": "sha512-5gf5nw5XH/2H/DJj8b0YkvG9fhA/4Jt6kL0Y8QjtztVjb1y4J19Rg4rG+fUbXu96gsUrlyIvZ3XfM0b4mogGmw==",
+      "requires": {
+        "abort-controller": "3.0.0",
+        "argsarray": "0.0.1",
+        "buffer-from": "1.1.1",
+        "clone-buffer": "1.0.0",
+        "double-ended-queue": "2.1.0-0",
+        "fetch-cookie": "0.10.1",
+        "immediate": "3.3.0",
+        "inherits": "2.0.4",
+        "level": "6.0.1",
+        "level-codec": "9.0.2",
+        "level-write-stream": "1.0.0",
+        "leveldown": "5.6.0",
+        "levelup": "4.4.0",
+        "ltgt": "2.2.1",
+        "node-fetch": "2.6.0",
+        "readable-stream": "1.1.14",
+        "spark-md5": "3.0.1",
+        "through2": "3.0.2",
+        "uuid": "8.1.0",
+        "vuvuzela": "1.0.3"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "immediate": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+          "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "readable-stream": "2 || 3"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+              "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+              "requires": {
+                "safe-buffer": "~5.2.0"
+              }
+            }
+          }
+        },
+        "uuid": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
+        }
+      }
+    },
+    "pouchdb-abstract-mapreduce": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-7.2.2.tgz",
+      "integrity": "sha512-7HWN/2yV2JkwMnGnlp84lGvFtnm0Q55NiBUdbBcaT810+clCGKvhssBCrXnmwShD1SXTwT83aszsgiSfW+SnBA==",
+      "requires": {
+        "pouchdb-binary-utils": "7.2.2",
+        "pouchdb-collate": "7.2.2",
+        "pouchdb-collections": "7.2.2",
+        "pouchdb-errors": "7.2.2",
+        "pouchdb-fetch": "7.2.2",
+        "pouchdb-mapreduce-utils": "7.2.2",
+        "pouchdb-md5": "7.2.2",
+        "pouchdb-utils": "7.2.2"
+      }
+    },
+    "pouchdb-binary-utils": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.2.2.tgz",
+      "integrity": "sha512-shacxlmyHbUrNfE6FGYpfyAJx7Q0m91lDdEAaPoKZM3SzAmbtB1i+OaDNtYFztXjJl16yeudkDb3xOeokVL3Qw==",
+      "requires": {
+        "buffer-from": "1.1.1"
+      }
+    },
+    "pouchdb-collate": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-7.2.2.tgz",
+      "integrity": "sha512-/SMY9GGasslknivWlCVwXMRMnQ8myKHs4WryQ5535nq1Wj/ehpqWloMwxEQGvZE1Sda3LOm7/5HwLTcB8Our+w=="
+    },
+    "pouchdb-collections": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.2.2.tgz",
+      "integrity": "sha512-6O9zyAYlp3UdtfneiMYuOCWdUCQNo2bgdjvNsMSacQX+3g8WvIoFQCYJjZZCpTttQGb+MHeRMr8m2U95lhJTew=="
+    },
+    "pouchdb-errors": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.2.2.tgz",
+      "integrity": "sha512-6GQsiWc+7uPfgEHeavG+7wuzH3JZW29Dnrvz8eVbDFE50kVFxNDVm3EkYHskvo5isG7/IkOx7PV7RPTA3keG3g==",
+      "requires": {
+        "inherits": "2.0.4"
+      }
+    },
+    "pouchdb-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-extend/-/pouchdb-extend-0.1.2.tgz",
+      "integrity": "sha1-0c5RG/cE7S4p979CikFqz/+hJLg="
+    },
+    "pouchdb-fetch": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-fetch/-/pouchdb-fetch-7.2.2.tgz",
+      "integrity": "sha512-lUHmaG6U3zjdMkh8Vob9GvEiRGwJfXKE02aZfjiVQgew+9SLkuOxNw3y2q4d1B6mBd273y1k2Lm0IAziRNxQnA==",
+      "requires": {
+        "abort-controller": "3.0.0",
+        "fetch-cookie": "0.10.1",
+        "node-fetch": "2.6.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        }
+      }
+    },
+    "pouchdb-find": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-find/-/pouchdb-find-7.2.2.tgz",
+      "integrity": "sha512-BmFeFVQ0kHmDehvJxNZl9OmIztCjPlZlVSdpijuFbk/Fi1EFPU1BAv3kLC+6DhZuOqU/BCoaUBY9sn66pPY2ag==",
+      "requires": {
+        "pouchdb-abstract-mapreduce": "7.2.2",
+        "pouchdb-collate": "7.2.2",
+        "pouchdb-errors": "7.2.2",
+        "pouchdb-fetch": "7.2.2",
+        "pouchdb-md5": "7.2.2",
+        "pouchdb-selector-core": "7.2.2",
+        "pouchdb-utils": "7.2.2"
+      }
+    },
+    "pouchdb-mapreduce-utils": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-7.2.2.tgz",
+      "integrity": "sha512-rAllb73hIkU8rU2LJNbzlcj91KuulpwQu804/F6xF3fhZKC/4JQMClahk+N/+VATkpmLxp1zWmvmgdlwVU4HtQ==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "inherits": "2.0.4",
+        "pouchdb-collections": "7.2.2",
+        "pouchdb-utils": "7.2.2"
+      }
+    },
+    "pouchdb-md5": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.2.2.tgz",
+      "integrity": "sha512-c/RvLp2oSh8PLAWU5vFBnp6ejJABIdKqboZwRRUrWcfGDf+oyX8RgmJFlYlzMMOh4XQLUT1IoaDV8cwlsuryZw==",
+      "requires": {
+        "pouchdb-binary-utils": "7.2.2",
+        "spark-md5": "3.0.1"
+      }
+    },
+    "pouchdb-promise": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-6.4.3.tgz",
+      "integrity": "sha512-ruJaSFXwzsxRHQfwNHjQfsj58LBOY1RzGzde4PM5CWINZwFjCQAhZwfMrch2o/0oZT6d+Xtt0HTWhq35p3b0qw==",
+      "requires": {
+        "lie": "3.1.1"
+      }
+    },
+    "pouchdb-selector-core": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-7.2.2.tgz",
+      "integrity": "sha512-XYKCNv9oiNmSXV5+CgR9pkEkTFqxQGWplnVhO3W9P154H08lU0ZoNH02+uf+NjZ2kjse7Q1fxV4r401LEcGMMg==",
+      "requires": {
+        "pouchdb-collate": "7.2.2",
+        "pouchdb-utils": "7.2.2"
+      }
+    },
+    "pouchdb-utils": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.2.2.tgz",
+      "integrity": "sha512-XmeM5ioB4KCfyB2MGZXu1Bb2xkElNwF1qG+zVFbQsKQij0zvepdOUfGuWvLRHxTOmt4muIuSOmWZObZa3NOgzQ==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.3.0",
+        "inherits": "2.0.4",
+        "pouchdb-collections": "7.2.2",
+        "pouchdb-errors": "7.2.2",
+        "pouchdb-md5": "7.2.2",
+        "uuid": "8.1.0"
+      },
+      "dependencies": {
+        "immediate": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+          "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+        },
+        "uuid": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
+          "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
+        }
+      }
+    },
+    "pouchdb-wrappers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-4.1.0.tgz",
+      "integrity": "sha512-L94K7zgb2tFSvU/iAj1EHK8fC13vKWzzy8kc9HBu9s1jtZSfD34cbWG6qUIvlu61Fso2byp8fsOvp+l5hFiRmg==",
+      "requires": {
+        "promise-nodify": "^1.0.2"
+      }
+    },
     "preact": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
@@ -14057,6 +16398,11 @@
         "ansi-styles": "^3.2.0",
         "react-is": "^16.8.4"
       }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "private-ip": {
       "version": "1.0.5",
@@ -14110,6 +16456,11 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
+    },
+    "promise-nodify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
+      "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
     },
     "promise-timeout": {
       "version": "1.3.0",
@@ -14204,6 +16555,15 @@
         }
       }
     },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -14284,6 +16644,11 @@
       "requires": {
         "bitcoin-ops": "^1.3.0"
       }
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qrcode": {
       "version": "1.4.4",
@@ -14387,6 +16752,32 @@
       "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
       "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
     },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "raw-ecdsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/raw-ecdsa/-/raw-ecdsa-1.1.1.tgz",
+      "integrity": "sha1-nSdqYNcSOZHworhG6kzMM0Br3P0=",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.1.0"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -14474,6 +16865,29 @@
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "requires": {
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
       }
     },
     "redent": {
@@ -14752,6 +17166,23 @@
         "nanoid": "^3.1.12"
       }
     },
+    "rsa-keygen": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/rsa-keygen/-/rsa-keygen-1.0.6.tgz",
+      "integrity": "sha1-PaO/gUfJYkfPaVaBsL2hem76QIY=",
+      "optional": true,
+      "requires": {
+        "nan": "~2.3.3"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+          "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
+          "optional": true
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -14910,6 +17341,48 @@
         }
       }
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -14917,6 +17390,29 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "servify": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
+      "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
+      "requires": {
+        "body-parser": "^1.16.0",
+        "cors": "^2.8.1",
+        "express": "^4.14.0",
+        "request": "^2.79.0",
+        "xhr": "^2.3.3"
       }
     },
     "set-blocking": {
@@ -14954,6 +17450,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -15552,6 +18053,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "spark-md5": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.1.tgz",
+      "integrity": "sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig=="
+    },
     "sparse-array": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
@@ -15669,6 +18175,11 @@
           }
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -16034,6 +18545,134 @@
         "has-flag": "^3.0.0"
       }
     },
+    "swarm-js": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+      "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "buffer": "^5.0.5",
+        "eth-lib": "^0.1.26",
+        "fs-extra": "^4.0.2",
+        "got": "^7.1.0",
+        "mime-types": "^2.1.16",
+        "mkdirp-promise": "^5.0.1",
+        "mock-fs": "^4.1.0",
+        "setimmediate": "^1.0.5",
+        "tar": "^4.0.2",
+        "xhr-request": "^1.0.1"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.1.29",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+          "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "requires": {
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "p-timeout": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+          "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -16056,6 +18695,27 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
     },
     "tdigest": {
       "version": "0.1.1",
@@ -16115,6 +18775,27 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thor-devkit": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/thor-devkit/-/thor-devkit-1.3.3.tgz",
+      "integrity": "sha512-IsxMfEF/NKvSpWN/RNOJPuBrNMgekAYkLJM+bxVEFtS5xQiv2gJsbdbT0CnWYv0CmT4j+zqdq2hyOBNccAZJZQ==",
+      "requires": {
+        "@vechain/ethers": "^4.0.27-3",
+        "bignumber.js": "^7.2.1",
+        "blakejs": "^1.1.0",
+        "elliptic": "6.5.3",
+        "fast-json-stable-stringify": "^2.0.0",
+        "js-sha3": "0.5.7",
+        "rlp": "^2.0.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        }
+      }
+    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -16124,6 +18805,11 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
       "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.2.3",
@@ -16300,6 +18986,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "token-types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
@@ -16324,6 +19015,52 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "transform-pouch": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/transform-pouch/-/transform-pouch-1.1.5.tgz",
+      "integrity": "sha512-X8hcWl3GnvSG3QMSBwsvVRCg9yRP3rSQd0wvZx2ZCGtZSrPxxe/l2wsjvETppD48rgA83XycxfPQ2fyOYRMU2w==",
+      "requires": {
+        "argsarray": "0.0.1",
+        "es3ify": "0.2.2",
+        "immediate": "~3.0.5",
+        "inherits": "2.0.1",
+        "lie": "3.0.4",
+        "pouchdb-extend": "0.1.2",
+        "pouchdb-promise": "5.4.3",
+        "pouchdb-wrappers": "4.1.0"
+      },
+      "dependencies": {
+        "immediate": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "lie": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
+          "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
+          "requires": {
+            "es3ify": "^0.2.2",
+            "immediate": "~3.0.5",
+            "inline-process-browser": "^1.0.0",
+            "unreachable-branch-transform": "^0.3.0"
+          }
+        },
+        "pouchdb-promise": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.3.tgz",
+          "integrity": "sha1-Mx1nCxmJ1aA/JogRIU8n9UFQyys=",
+          "requires": {
+            "lie": "3.0.4"
+          }
+        }
       }
     },
     "trim-newlines": {
@@ -16468,6 +19205,16 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -16485,6 +19232,15 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -16558,6 +19314,11 @@
         "web-encoding": "^1.0.2"
       }
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -16604,6 +19365,79 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unreachable-branch-transform": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
+      "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
+      "requires": {
+        "esmangle-evaluator": "^1.0.0",
+        "recast": "^0.10.1",
+        "through2": "^0.6.2"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.15",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "recast": {
+          "version": "0.10.43",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+          "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+          "requires": {
+            "ast-types": "0.8.15",
+            "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
     },
     "unset-value": {
       "version": "1.0.0",
@@ -16759,6 +19593,14 @@
         }
       }
     },
+    "url-exists": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-exists/-/url-exists-1.0.3.tgz",
+      "integrity": "sha1-BbKHW68ElQ4n71HphG8e/wRxaJM=",
+      "requires": {
+        "request": "^2.69.0"
+      }
+    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -16786,6 +19628,11 @@
       "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
       "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
     },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
     "ursa-optional": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
@@ -16799,6 +19646,21 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "utf-8-validate": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
+      "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
+      "requires": {
+        "node-gyp-build": "^4.2.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+        }
+      }
     },
     "utf8": {
       "version": "3.0.0",
@@ -16842,6 +19704,11 @@
         "has-symbols": "^1.0.1",
         "object.getownpropertydescriptors": "^2.1.0"
       }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",
@@ -16906,6 +19773,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -16921,6 +19793,11 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "vuvuzela": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuvuzela/-/vuvuzela-1.0.3.tgz",
+      "integrity": "sha1-O+FF5YJxxzylUnndhR8SpoIRSws="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -17080,6 +19957,609 @@
       "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
       "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
     },
+    "web3": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.0.tgz",
+      "integrity": "sha512-4q9dna0RecnrlgD/bD1C5S+81Untbd6Z/TBD7rb+D5Bvvc0Wxjr4OP70x+LlnwuRDjDtzBwJbNUblh2grlVArw==",
+      "requires": {
+        "web3-bzz": "1.3.0",
+        "web3-core": "1.3.0",
+        "web3-eth": "1.3.0",
+        "web3-eth-personal": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-shh": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-bzz": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.0.tgz",
+      "integrity": "sha512-ibYAnKab+sgTo/UdfbrvYfWblXjjgSMgyy9/FHa6WXS14n/HVB+HfWqGz2EM3fok8Wy5XoKGMvdqvERQ/mzq1w==",
+      "requires": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40",
+        "underscore": "1.9.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
+          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+        }
+      }
+    },
+    "web3-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.0.tgz",
+      "integrity": "sha512-BwWvAaKJf4KFG9QsKRi3MNoNgzjI6szyUlgme1qNPxUdCkaS3Rdpa0VKYNHP7M/YTk82/59kNE66mH5vmoaXjA==",
+      "requires": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-requestmanager": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
+          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-helpers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.0.tgz",
+      "integrity": "sha512-+MFb1kZCrRctf7UYE7NCG4rGhSXaQJ/KF07di9GVK1pxy1K0+rFi61ZobuV1ky9uQp+uhhSPts4Zp55kRDB5sw==",
+      "requires": {
+        "underscore": "1.9.1",
+        "web3-eth-iban": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-method": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.0.tgz",
+      "integrity": "sha512-h0yFDrYVzy5WkLxC/C3q+hiMnzxdWm9p1T1rslnuHgOp6nYfqzu/6mUIXrsS4h/OWiGJt+BZ0xVZmtC31HDWtg==",
+      "requires": {
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "underscore": "1.9.1",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-core-promievent": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.0.tgz",
+      "integrity": "sha512-blv69wrXw447TP3iPvYJpllkhW6B18nfuEbrfcr3n2Y0v1Jx8VJacNZFDFsFIcgXcgUIVCtOpimU7w9v4+rtaw==",
+      "requires": {
+        "eventemitter3": "4.0.4"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        }
+      }
+    },
+    "web3-core-requestmanager": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.0.tgz",
+      "integrity": "sha512-3yMbuGcomtzlmvTVqNRydxsx7oPlw3ioRL6ReF9PeNYDkUsZaUib+6Dp5eBt7UXh5X+SIn/xa1smhDHz5/HpAw==",
+      "requires": {
+        "underscore": "1.9.1",
+        "web3-core-helpers": "1.3.0",
+        "web3-providers-http": "1.3.0",
+        "web3-providers-ipc": "1.3.0",
+        "web3-providers-ws": "1.3.0"
+      }
+    },
+    "web3-core-subscriptions": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.0.tgz",
+      "integrity": "sha512-MUUQUAhJDb+Nz3S97ExVWveH4utoUnsbPWP+q1HJH437hEGb4vunIb9KvN3hFHLB+aHJfPeStM/4yYTz5PeuyQ==",
+      "requires": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.9.1",
+        "web3-core-helpers": "1.3.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        }
+      }
+    },
+    "web3-eth": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.0.tgz",
+      "integrity": "sha512-/bzJcxXPM9EM18JM5kO2JjZ3nEqVo3HxqU93aWAEgJNqaP/Lltmufl2GpvIB2Hvj+FXAjAXquxUdQ2/xP7BzHQ==",
+      "requires": {
+        "underscore": "1.9.1",
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-eth-accounts": "1.3.0",
+        "web3-eth-contract": "1.3.0",
+        "web3-eth-ens": "1.3.0",
+        "web3-eth-iban": "1.3.0",
+        "web3-eth-personal": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-abi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.0.tgz",
+      "integrity": "sha512-1OrZ9+KGrBeBRd3lO8upkpNua9+7cBsQAgor9wbA25UrcUYSyL8teV66JNRu9gFxaTbkpdrGqM7J/LXpraXWrg==",
+      "requires": {
+        "@ethersproject/abi": "5.0.0-beta.153",
+        "underscore": "1.9.1",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "@ethersproject/abi": {
+          "version": "5.0.0-beta.153",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
+          "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
+          "requires": {
+            "@ethersproject/address": ">=5.0.0-beta.128",
+            "@ethersproject/bignumber": ">=5.0.0-beta.130",
+            "@ethersproject/bytes": ">=5.0.0-beta.129",
+            "@ethersproject/constants": ">=5.0.0-beta.128",
+            "@ethersproject/hash": ">=5.0.0-beta.128",
+            "@ethersproject/keccak256": ">=5.0.0-beta.127",
+            "@ethersproject/logger": ">=5.0.0-beta.129",
+            "@ethersproject/properties": ">=5.0.0-beta.131",
+            "@ethersproject/strings": ">=5.0.0-beta.130"
+          }
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-accounts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.0.tgz",
+      "integrity": "sha512-/Q7EVW4L2wWUbNRtOTwAIrYvJid/5UnKMw67x/JpvRMwYC+e+744P536Ja6SG4X3MnzFvd3E/jruV4qa6k+zIw==",
+      "requires": {
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
+        "scrypt-js": "^3.0.1",
+        "underscore": "1.9.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "ethereumjs-tx": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
+          "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
+          "requires": {
+            "ethereumjs-common": "^1.5.0",
+            "ethereumjs-util": "^6.0.0"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-contract": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.0.tgz",
+      "integrity": "sha512-3SCge4SRNCnzLxf0R+sXk6vyTOl05g80Z5+9/B5pERwtPpPWaQGw8w01vqYqsYBKC7zH+dxhMaUgVzU2Dgf7bQ==",
+      "requires": {
+        "@types/bn.js": "^4.11.5",
+        "underscore": "1.9.1",
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.0.tgz",
+      "integrity": "sha512-WnOru+EcuM5dteiVYJcHXo/I7Wq+ei8RrlS2nir49M0QpYvUPGbCGgTbifcjJQTWamgORtWdljSA1s2Asdb74w==",
+      "requires": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.9.1",
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-eth-contract": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.0.tgz",
+      "integrity": "sha512-v9mZWhR4fPF17/KhHLiWir4YHWLe09O3B/NTdhWqw3fdAMJNztzMHGzgHxA/4fU+rhrs/FhDzc4yt32zMEXBZw==",
+      "requires": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-personal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.0.tgz",
+      "integrity": "sha512-2czUhElsJdLpuNfun9GeLiClo5O6Xw+bLSjl3f4bNG5X2V4wcIjX2ygep/nfstLLtkz8jSkgl/bV7esANJyeRA==",
+      "requires": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.19.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.7.tgz",
+          "integrity": "sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A=="
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-net": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.0.tgz",
+      "integrity": "sha512-Xz02KylOyrB2YZzCkysEDrY7RbKxb7LADzx3Zlovfvuby7HBwtXVexXKtoGqksa+ns1lvjQLLQGb+OeLi7Sr7w==",
+      "requires": {
+        "web3-core": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-utils": "1.3.0"
+      },
+      "dependencies": {
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+          "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
     "web3-provider-engine": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-15.0.12.tgz",
@@ -17158,6 +20638,54 @@
             "async-limiter": "~1.0.0"
           }
         }
+      }
+    },
+    "web3-providers-http": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.0.tgz",
+      "integrity": "sha512-cMKhUI6PqlY/EC+ZDacAxajySBu8AzW8jOjt1Pe/mbRQgS0rcZyvLePGTTuoyaA8C21F8UW+EE5jj7YsNgOuqA==",
+      "requires": {
+        "web3-core-helpers": "1.3.0",
+        "xhr2-cookies": "1.1.0"
+      }
+    },
+    "web3-providers-ipc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.0.tgz",
+      "integrity": "sha512-0CrLuRofR+1J38nEj4WsId/oolwQEM6Yl1sOt41S/6bNI7htdkwgVhSloFIMJMDFHtRw229QIJ6wIaKQz0X1Og==",
+      "requires": {
+        "oboe": "2.1.5",
+        "underscore": "1.9.1",
+        "web3-core-helpers": "1.3.0"
+      }
+    },
+    "web3-providers-ws": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.0.tgz",
+      "integrity": "sha512-Im5MthhJnJst8nSoq0TgbyOdaiFQFa5r6sHPOVllhgIgViDqzbnlAFW9sNzQ0Q8VXPNfPIQKi9cOrHlSRNPjRw==",
+      "requires": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.9.1",
+        "web3-core-helpers": "1.3.0",
+        "websocket": "^1.0.32"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
+        }
+      }
+    },
+    "web3-shh": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.0.tgz",
+      "integrity": "sha512-IZTojA4VCwVq+7eEIHuL1tJXtU+LJDhO8Y2QmuwetEWW1iBgWCGPHZasipWP+7kDpSm/5lo5GRxL72FF/Os/tA==",
+      "requires": {
+        "web3-core": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-net": "1.3.0"
       }
     },
     "web3-utils": {
@@ -17337,6 +20865,34 @@
         "source-map": "~0.6.1"
       }
     },
+    "websocket": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+      "requires": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -17490,6 +21046,21 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "write-stream": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/write-stream/-/write-stream-0.4.3.tgz",
+      "integrity": "sha1-g8yMA0fQr2BXqThitOOuAd5cgcE=",
+      "requires": {
+        "readable-stream": "~0.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-0.0.4.tgz",
+          "integrity": "sha1-8y124/uGM0SlSNeZIwBxc2ZbO40="
+        }
+      }
+    },
     "ws": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
@@ -17592,6 +21163,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@ceramicnetwork/key-did-resolver": "^0.1.2",
     "@ceramicstudio/idx-tools": "^0.3.1",
     "@ceramicstudio/idx-web": "^0.2.0",
+    "@verida/datastore": "^0.6.3",
+    "@verida/wallet-utils": "^1.2.0",
     "@walletconnect/web3-provider": "^1.3.1",
     "authereum": "^0.1.0",
     "dag-jose": "^0.3.0",

--- a/src/verida.ts
+++ b/src/verida.ts
@@ -91,6 +91,12 @@ const authenticate = async (): Promise<void> => {
   console.log(
     'You can then run `await testDb.getMany()` to load the saved data'
   )
+  console.log(
+    '---'
+  )
+  console.log(
+    'Learn more about creating permissioned databases, datastores, schemas, messaging etc. in the Verida documentation: https://docs.datastore.verida.io/'
+  )
 }
 
 document.getElementById('bauth')?.addEventListener('click', () => {

--- a/src/verida.ts
+++ b/src/verida.ts
@@ -1,0 +1,100 @@
+import { createDefinition, publishSchema } from '@ceramicstudio/idx-tools'
+import type { JWE } from 'did-jwt'
+import type { DID } from 'dids'
+// @ts-ignore
+import Verida from '@verida/datastore'
+import WalletUtils from '@verida/wallet-utils'
+// @ts-ignore
+import { fromString, toString } from 'uint8arrays'
+
+import { createCeramic } from './ceramic'
+import { createIDX } from './idx'
+import { getAuthProvider } from './wallet'
+
+declare global {
+  interface Window {
+    did?: DID
+  }
+}
+
+const ceramicPromise = createCeramic()
+
+const VeridaSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'Ethereum wallet',
+  type: 'object',
+}
+
+const authenticate = async (): Promise<void> => {
+  console.log('Authenticating...')
+
+  const [authProvider, ceramic] = await Promise.all([getAuthProvider(), ceramicPromise])
+  const idx = await createIDX(ceramic, { authProvider })
+
+  window.did = idx.did
+  console.log('Authenticated with DID:', idx.id)
+
+  console.log('Creating IDX setup...')
+  // @ts-ignore
+  const schemaID = await publishSchema(ceramic, { content: VeridaSchema })
+  const definitionID = await createDefinition(ceramic, {
+    name: 'Ethereum key',
+    description: 'Ethereum key for connecting to Verida applications',
+    schema: schemaID.toUrl('base36'),
+  })
+  const seedKey = definitionID.toString()
+  console.log('IDX setup created with definition ID:', seedKey)
+
+  const createWallet = async (): Promise<object> => {
+    const wallet = WalletUtils.createWallet('ethr')
+    const jwe = await idx.did.createJWE(fromString(JSON.stringify(wallet)), [idx.id])
+    await idx.set(seedKey, jwe)
+    return wallet
+  }
+  // @ts-ignore
+  window.createWallet = createWallet
+
+  const getVerida = async (appName: string): Promise<any | null> => {
+    const jwe = await idx.get<JWE>(seedKey)
+    if (jwe == null) {
+      return null
+    }
+    const decrypted = await idx.did.decryptJWE(jwe)
+    const wallet = JSON.parse(toString(decrypted))
+    const app = new Verida({
+      appName: appName,
+      chain: wallet.chain,
+      address: wallet.address,
+      privateKey: wallet.privateKey
+    })
+    return app
+  }
+  // @ts-ignore
+  window.getVerida = getVerida
+
+  console.log('Next steps:')
+  console.log(
+    'Run `wallet = await createWallet()` to create a new Ethereum wallet and save it with IDX'
+  )
+  console.log(
+    'You can then run `verida = await getVerida("My application name")` to retrieve the saved Ethereum wallet and create a new Verida application instance for the given application name'
+  )
+  console.log(
+    'Run `await verida.connect()` to initialize the Verida application instance'
+  )
+  console.log(
+    'Run `testDb = await verida.openDatabase("myEncryptedDatabase")` to open an encrypted database'
+  )
+  console.log(
+    'Run `await testDb.save({hello: "Verida with IDX"})` to save data in your encrypted test database'
+  )
+  console.log(
+    'You can then run `await testDb.getMany()` to load the saved data'
+  )
+}
+
+document.getElementById('bauth')?.addEventListener('click', () => {
+  authenticate().catch((err) => {
+    console.error('Failed to authenticate:', err)
+  })
+})

--- a/verida.html
+++ b/verida.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>IDX + SkyDB Playground</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <style>
+      body {
+        background-color: #f7f7f9;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <p>Open your console and click the button below to authenticate</p>
+    <button id="bauth" type="button" class="btn btn-primary" style="margin: 50px 100px;">Let's start!</button>
+    <p><a href="https://medium.com/@verida/introducing-verida-datastore-an-encrypted-client-side-database-solution-for-dapps-2ad41c8b4242">Learn more about Verida</a></p>
+  </body>
+
+  <script type="text/javascript" src="dist/verida.js"></script>
+</html>

--- a/verida.html
+++ b/verida.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>IDX + SkyDB Playground</title>
+    <title>IDX + Verida Playground</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   entry: {
     app: './src/app.ts',
     skydb: './src/skydb.ts',
+    verida: './src/verida.ts',
   },
   output: {
     filename: '[name].js',


### PR DESCRIPTION
This PR adds an example of connecting Verida Datastore to enable using verida for dApps to support encrypted user databases, DID P2P messaging etc.

More information about Verida is available here:
- [Introducing Verida Datastore](https://medium.com/@verida/introducing-verida-datastore-an-encrypted-client-side-database-solution-for-dapps-2ad41c8b4242)
- [Verida Datastore Documentation](https://docs.datastore.verida.io/)
- [Developer Sandbox](https://sandbox.datastore.verida.io/)

---

The example in this demo is a quick proof of concept, but will be improved with an upcoming Verida release that refactors key management, authorization and DID discovery.

Verida has the same issues that 3box had with having Ethereum users sign a consent message on a per application basis and that metadata needing to be stored somewhere. The Verida approach is to create a new Verida DID method and use that to create a DID for each combination of Ethereum Wallet + Application, similar to how 3box creates a 3ID and links that to each application via a consent message.

The approach in this demo is less than ideal and ends up with the following hierarchy of Wallets (and DIDs): User's Ethereum Wallet -> 3ID Wallet -> Another Ethereum Wallet -> Verida Wallet -> DID metadata (public keys, URI endpoints etc.)

A future release of the Verida Datastore will refactor this so things can be more modular and flexible, which will allow the 3ID DID to maintain the metadata about connected apps and negate the need for a Verida Wallet.

This will result in this much simpler hierarchy: User's Ethereum Wallet -> 3ID Wallet -> DID metadata (public keys, URI endpoints etc.)